### PR TITLE
Fix AbstractMutationError

### DIFF
--- a/src/Application/ResponseRecorder/MutationResponse/ErrorCollection/AbstractMutationError.php
+++ b/src/Application/ResponseRecorder/MutationResponse/ErrorCollection/AbstractMutationError.php
@@ -2,7 +2,7 @@
 
 namespace TomCizek\ResponseRecorder\Application\ResponseRecorder\MutationResponse\ErrorCollection;
 
-class AbstractMutationError implements ShowableMutationError
+abstract class AbstractMutationError implements ShowableMutationError
 {
 	/** @var string */
 	protected $errorMessage;


### PR DESCRIPTION
Well if the class has "Abstract" in the name then it should be abstract, right?